### PR TITLE
Fix for https://github.com/eezstreet/SWATEliteForce/issues/567

### DIFF
--- a/Source/Game/SwatAICommon/Classes/Actions/ShareEquipmentAction.uc
+++ b/Source/Game/SwatAICommon/Classes/Actions/ShareEquipmentAction.uc
@@ -73,7 +73,15 @@ latent function GiveEquipment()
 	}
 
 	EquipmentPiece.LatentGive(Destination);
-
+	
+	// Remove the optiwand from the officers "GivenEquipment"
+	// or else we wont be able to give the officer the item again
+	// since it will still be in the equipment array.
+	if(EquipmentPiece.IsA('Optiwand'))
+	{
+		ISwatOfficer(m_Pawn).RemoveGivenEquipment(EquipmentPiece);
+	}
+    
 	ISwatAI(m_Pawn).UnlockAim();
 }
 

--- a/Source/Game/SwatAICommon/Classes/ISwatOfficer.uc
+++ b/Source/Game/SwatAICommon/Classes/ISwatOfficer.uc
@@ -40,6 +40,8 @@ function FiredWeapon		GetPrimaryWeapon();
 function FiredWeapon		GetBackupWeapon();
 function bool HasA(name EquipmentClass);
 
+function RemoveGivenEquipment(HandheldEquipment Equipment);
+
 function ReEquipFiredWeapon();
 function InstantReEquipFiredWeapon();
 

--- a/Source/Game/SwatGame/Classes/AI/SwatOfficer.uc
+++ b/Source/Game/SwatGame/Classes/AI/SwatOfficer.uc
@@ -768,6 +768,11 @@ function HandheldEquipment GetItemAtSlot(EquipmentSlot Slot)
 	return LoadOut.GetItemAtSlot(Slot);
 }
 
+function RemoveGivenEquipment(HandheldEquipment Equipment)
+{
+    LoadOut.RemoveGivenEquipment(Equipment);
+}
+
 // overridden from ISwatAI
 function float GetTimeToWaitBeforeFiring()
 {

--- a/Source/Game/SwatGame/Classes/LoadOut/EliteLoadout.uc
+++ b/Source/Game/SwatGame/Classes/LoadOut/EliteLoadout.uc
@@ -13,6 +13,21 @@ function ClientAddItemToGivenEquipment(Actor newItem)
 	GivenEquipment[GivenEquipment.Length] = newItem;
 }
 
+simulated function RemoveGivenEquipment(HandHeldEquipment Equipment)
+{
+	local int i;
+	local HandheldEquipment Item;
+
+	for(i = 0; i < GivenEquipment.Length; i++)
+	{
+		Item = HandheldEquipment(GivenEquipment[i]);
+		if(Item == Equipment)
+		{
+			GivenEquipment.Remove(i, 1);
+		}
+	}
+}
+
 simulated function HandHeldEquipment FindGivenItemForSlot(EquipmentSlot Slot)
 {
 	local int i;

--- a/Source/Game/SwatGame/Classes/LoadOut/LoadOut.uc
+++ b/Source/Game/SwatGame/Classes/LoadOut/LoadOut.uc
@@ -559,6 +559,8 @@ simulated function HandHeldEquipment GetFirstAvailableItemAtSlot(EquipmentSlot S
     return Candidate;
 }
 
+simulated function RemoveGivenEquipment(HandHeldEquipment Equipment) {}
+
 // Returns the first handheld equipment corresponding to the given slot
 simulated function HandheldEquipment GetItemAtSlot(EquipmentSlot Slot)
 {

--- a/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
+++ b/Source/Game/SwatGame/Classes/SwatGamePlayerController.uc
@@ -2471,10 +2471,13 @@ simulated private function InternalEquipSlot(coerce EquipmentSlot Slot)
     if ( PendingItem != None && PendingItem.GetSlot() == Slot)
         return;     //already in the process of equipping that
 
-    // If the player has none of the requested item then
-    //  show a message on the HUD
-    if ( SwatPlayer.GetEquipmentAtSlot(Slot) == None )
+    // If the player has none of the requested item then show a message on the HUD.
+    // When we send a message that we cannot equip, we return as well to avoid equipping anyways.
+    if ( SwatPlayer.GetEquipmentAtSlot(Slot) == None || (!SwatPlayer.GetEquipmentAtSlot(Slot).IsAvailable()) )
+    {
         ClientMessage(string(int(Slot)), 'EquipNotAvailable');
+        return;
+    }
 
     if ( SwatPlayer.ValidateEquipSlot( Slot ))
     {


### PR DESCRIPTION
- When AI officers give the player the optiwand, it will remove it from the "GivenEquipment" array.
  Allowing the player to give the optiwand back to the AI officer.
- Fixes the player equiping an item that is unavailable using an additional check.
- Short circuits equipping when the client message is sent that an item is missing or unavailable.