### PR TITLE
Fixed weight and bulk values for grenades

### DIFF
--- a/System/SwatEquipment.ini
+++ b/System/SwatEquipment.ini
@@ -7300,14 +7300,14 @@ Bulk=0.5852
 [SwatEquipment.Flashbang3pack]
 PlayerUsable=true
 StartCount=3
-Weight=0.42
-Bulk=0.5852
+Weight=0.70
+Bulk=0.9753
 
 [SwatEquipment.Flashbang6pack]
 PlayerUsable=true
 StartCount=6
-Weight=0.42
-Bulk=0.5852
+Weight=1.12
+Bulk=1.5650
 
 [SwatEquipment.FlashbangGrenadeProjectile]
 ;timer
@@ -7373,17 +7373,20 @@ NotifyAIsTime=0.75
 AIStunDuration=10.0
 MoraleModifier=0.4
 
+Weight=0.550
+Bulk=0.7852
+
 [SwatEquipment.Ninebang3pack]
 PlayerUsable=true
 StartCount=3
-Weight=0.42
-Bulk=0.5852
+Weight=0.9166
+Bulk=1.3086
 
 [SwatEquipment.Ninebang6pack]
 PlayerUsable=true
 StartCount=6
-Weight=0.42
-Bulk=0.5852
+Weight=1.4666
+Bulk=2.0938
 
 ;********************************
 ;CS TEAR GAS GRENADE
@@ -7409,14 +7412,14 @@ Bulk=0.798
 [SwatEquipment.CS3pack]
 PlayerUsable=true
 StartCount=3
-Weight=0.43
-Bulk=0.798
+Weight=0.71
+Bulk=1.33
 
 [SwatEquipment.CS6pack]
 PlayerUsable=true
 StartCount=6
-Weight=0.43
-Bulk=0.798
+Weight=1.146
+Bulk=2.128
 
 [SwatEquipment.CSGasGrenadeProjectile]
 ;timer
@@ -7482,20 +7485,20 @@ UnequipAnimationRate=1.5
 UseAnimationRate=1
 LightstickThrowAnimPostfix="StringGrenade"
 
-Weight=0.28
+Weight=0.31
 Bulk=1.036
 
 [SwatEquipment.Sting3pack]
 PlayerUsable=true
 StartCount=3
-Weight=0.28
-Bulk=1.036
+Weight=0.52
+Bulk=1.7267
 
 [SwatEquipment.Sting6pack]
 PlayerUsable=true
 StartCount=6
-Weight=0.28
-Bulk=1.036
+Weight=0.826
+Bulk=2.7626
 
 [SwatEquipment.StingGrenadeProjectile]
 ;timer


### PR DESCRIPTION
Fixed weight for stinger (including x3 and x6 pack)
Fixed weight for Flashbang (x3 and x6 pack only)
Fixed weight for CS Gas (x3 and x6 pack only)
Fixed weight for Ninebang (including x3 and x6 pack)

Formula used for x3 pack: 1 grenade weight x 5/3 
Formula used for x6 pack: 1 grenade weight × 8/3
Same formula used for bulk, SEF devs used this formula.